### PR TITLE
Add max_labels input to action and update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
       - main
 permissions:
   contents: read
+  models: read
+  pull-requests: write
   issues: write
 jobs:
   test:
@@ -28,4 +30,5 @@ jobs:
       - uses: ./
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          max_labels: 3
           github_issue: "2"

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: action-genai-issue-labeller
 description: Labels GitHub issues based on their content using GitHub Models.
 inputs:
+  max_labels:
+    description: Maximum number of labels to suggest.
+    required: false
   instructions:
     description:
       Additional Instructions for the AI model to follow when labeling

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "typecheck": "genaiscript scripts compile",
     "configure": "genaiscript configure action",
     "test": "echo 'No tests defined.'",
-    "dev": "GITHUB_ISSUE=4 DEBUG=script* genaiscript run action",
-    "start": "genaiscript run action --github-workspace",
+    "dev": "INPUT_MAX_LABELS=1 INPUT_GITHUB_ISSUE=4 DEBUG=script* genaiscript run action",
+    "start": "genaiscript run action --github-workspace --no-run-trace --no-output-trace",
     "release": "sh release.sh"
   },
   "version": "0.0.19"

--- a/release.sh
+++ b/release.sh
@@ -1,3 +1,4 @@
+
 # make sure there's no other changes
 git pull
 


### PR DESCRIPTION
Introduce a `max_labels` input to limit the number of suggested labels for GitHub issues. Update the CI workflow to accommodate this new input.